### PR TITLE
Re-map Skipped & Undefined (Follow Allure Convention)

### DIFF
--- a/lib/allure-cucumber/formatter.rb
+++ b/lib/allure-cucumber/formatter.rb
@@ -143,9 +143,9 @@ module AllureCucumber
     def cucumber_status_to_allure_status(status)
       case status.to_s
       when "undefined"
-        return "failed"
+        return "broken"
       when "skipped"
-        return "pending"
+        return "canceled"
       else
         return status.to_s
       end


### PR DESCRIPTION
Hey,

In 2 cases we take distinct cucumber statuses and lump them together, which reduces users ability to highlight / separate their results.
Specifically we map ```skipped``` to ```pending```, and ```undefined``` to ```failed``` , where ```pending``` & ```failed``` are already being used.

As such, I thought it would be smart to map ```skipped``` & ```undefined``` to something else.

I took some time to go through the allure statuses, and came across a thread where the allure-devs stated that ```canceled``` is an equivalent of ```skipped``` , and ```broken``` describes the result of ```undefined```. 

https://github.com/allure-framework/allure-rspec/issues/28
```
By: vania-pooh 
@maticon canceled = skipped because of e.g. test dependencies. pending = not implemented.
```

```
By: @smecsia 
Broken ( test error ) When a test is run, an error that keeps the test from running to completion. The error may be explicitly raised or thrown by the system under test (SUT) or by the test itself, or it may be thrown by the runtime system (e.g., operating system, virtual machine). In general, it is much easier to debug a test error than a test failure because the cause of the problem tends to be much more local to where the test error occurs. Compare with test failure and test success.```

If we accept this PR then we will be able to have a unique mapping for each major cucumber result

1. passed = passed
2. failed = failed
3. pending = pending
4. skipped = canceled
5. undefined = broken